### PR TITLE
Action Patch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,9 +11,9 @@ jobs:
     if: contains(github.event.head_commit.message, '[Skip-CI]') == false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -37,7 +37,7 @@ jobs:
         echo Last build tool version is: $BUILD_TOOL_VERSION
 
     - name: Sign app APK (Standard)
-      uses: r0adkll/sign-android-release@v1
+      uses: noriban/sign-android-release@v5.1
       id: sign_standard
       with:
         releaseDirectory: app/build/outputs/apk/standard/release
@@ -49,7 +49,7 @@ jobs:
         BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
     - name: Sign app APK (Quest)
-      uses: r0adkll/sign-android-release@v1
+      uses: noriban/sign-android-release@v5.1
       id: sign_quest
       with:
         releaseDirectory: app/build/outputs/apk/quest/release

--- a/fastlane/metadata/android/en-US/changelogs/100200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100200.txt
@@ -1,0 +1,22 @@
+New:
+
+- French Translation (credit: guerryer)
+
+Fixes:
+
+- Now you can navigate back through tabs & sections
+- UI state may not recompose
+- User groups didn't load due to bad request
+- user location was empty in Feed
+- Don't show duplicate Friend Locations
+- Prevent duplicate Feed events
+
+Changes:
+
+- Favorite friends are now shown regardless of status
+- Friend Locations is now above Offline Friends
+
+Misc:
+
+- change PipelineService type to specialUse
+- target Android 15


### PR DESCRIPTION
+ Checkout + Jave Enviroment Setup + Signer replaced with ongoing release
Tested on VM and not has issue for while so should be good to go.

+ Auto Publish fuction has few option to replaced to so I left as it is.
Seems GitHub prefer "GitHub CLI (GH Release Create)" over currnet usage so may need to check on those for feature proofing.