### PR TITLE
Check for profile picture override when viewing avatar.

### DIFF
--- a/app/src/main/java/cc/sovellus/vrcaa/ui/screen/profile/UserProfileScreen.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/ui/screen/profile/UserProfileScreen.kt
@@ -153,6 +153,15 @@ class UserProfileScreen(
                                         DropdownMenuItem(
                                             onClick = {
                                                 model.findAvatar { avatarId ->
+                                                    @Suppress("SENSELESS_COMPARISON")
+                                                    if(profile.profilePicOverride != null){
+                                                        Toast.makeText(
+                                                            context,
+                                                            context.getString(R.string.profile_user_avatar_unreachable),
+                                                            Toast.LENGTH_SHORT
+                                                        ).show()
+                                                        return@findAvatar Unit
+                                                    }
                                                     if (avatarId == null)  {
                                                         Toast.makeText(
                                                             context,

--- a/app/src/main/java/cc/sovellus/vrcaa/ui/screen/profile/UserProfileScreen.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/ui/screen/profile/UserProfileScreen.kt
@@ -153,8 +153,7 @@ class UserProfileScreen(
                                         DropdownMenuItem(
                                             onClick = {
                                                 model.findAvatar { avatarId ->
-                                                    @Suppress("SENSELESS_COMPARISON")
-                                                    if(profile.profilePicOverride != null){
+                                                    if(profile.profilePicOverride.isNotEmpty()){
                                                         Toast.makeText(
                                                             context,
                                                             context.getString(R.string.profile_user_avatar_unreachable),

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Selber einladen</string>
     <string name="profile_user_not_found_message">Benutzer existiert nicht.</string>
     <string name="profile_user_avatar_private">Avatar ist privat!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Einladung gesendet. Überprüfe dein Spiel.</string>
     <string name="profile_mutual_groups_text">Gemeinsame Gruppen</string>
     <!-- Search -->

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Kutsu itseni</string>
     <string name="profile_user_not_found_message">Käyttäjää ei ole olemassa.</string>
     <string name="profile_user_avatar_private">Hahmo on yksityinen!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Kutsu lähetetty! Tarkista pelisi.</string>
     <string name="profile_mutual_groups_text">Yhteiset Ryhmät</string>
     <!-- Search -->

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">S\'envoyer une invitation</string>
     <string name="profile_user_not_found_message">L\'utilisateur n\'existe pas.</string>
     <string name="profile_user_avatar_private">L\'avatar est privé !</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invitation envoyée ! Regardez VRChat.</string>
     <string name="profile_mutual_groups_text">Groupes mutuels</string>
     <!-- Search -->

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">L\'utente non esiste.</string>
     <string name="profile_user_avatar_private">Avatar privato!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invito inviato! Controlla il tuo client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">セルフ・インバイト</string>
     <string name="profile_user_not_found_message">このユーザーは存在しません。</string>
     <string name="profile_user_avatar_private">このアバターはプライベートです。</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">インバイトを送信しました、ゲーム内で確認してください。</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">Użytkownik nie istnieje.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Пригласить самого себя</string>
     <string name="profile_user_not_found_message">Юзер не существует.</string>
     <string name="profile_user_avatar_private">Аватар является приватным!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Приглашение отправлено! Проверьте ваш клиент игры.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Kendimi davet et</string>
     <string name="profile_user_not_found_message">Kullanıcı bulunamadı.</string>
     <string name="profile_user_avatar_private">Avatar özel!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Davet gönderildi! Oyunu kontrol et.</string>
     <string name="profile_mutual_groups_text">Ortak guruplar</string>
     <!-- Search -->

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -40,6 +40,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
     <!-- Search -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="profile_user_dropdown_invite_self">Invite myself</string>
     <string name="profile_user_not_found_message">User doesn\'t exist.</string>
     <string name="profile_user_avatar_private">Avatar is private!</string>
+    <string name="profile_user_avatar_unreachable">Avatar is unreachable!</string>
     <string name="profile_user_toast_invite_sent">Invite sent! Check your game client.</string>
     <string name="profile_mutual_groups_text">Mutual Groups</string>
 


### PR DESCRIPTION
When a user has VRCPlus and sets a Profile Picture Override the current avatar thumbnail URL will be overwritten to VRChat's default Robot avatar, it will now return "Avatar is unreachable!" in this case.