### PR TITLE
Avatar search by FileID and by author

### DIFF
--- a/app/src/main/java/cc/sovellus/vrcaa/api/search/justhparty/JustHPartyProvider.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/api/search/justhparty/JustHPartyProvider.kt
@@ -41,5 +41,15 @@ class JustHPartyProvider : BaseClient() {
         }
     }
 
+    suspend fun searchByAuthor(query: String): ArrayList<SearchAvatar>
+    {
+        return when (val result = sendRequest("?authorId=${URLEncoder.encode(query)}")) {
+            is String -> {
+                Gson().fromJson(result, Avatars::class.java) ?: arrayListOf()
+            }
+            else -> arrayListOf()
+        }
+    }
+
     class Avatars : ArrayList<SearchAvatar>()
 }


### PR DESCRIPTION
The name of an avatar within the thumbnail is permanent and only set once at initial upload, if the name of an avatar changes it will only reflect that in the API causing a possible mismatch, this changes all searches to check for matching FileID instead as its more accurate, also implements fallback search by author ID.