### PR TITLE
change to Long for version primitives

### DIFF
--- a/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/Avatar.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/Avatar.kt
@@ -37,5 +37,5 @@ data class Avatar(
     @SerializedName("updated_at")
     var updatedAt: String = "",
     @SerializedName("version")
-    var version: Int = 0
+    var version: Long = 0
 )

--- a/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/FavoriteAvatar.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/FavoriteAvatar.kt
@@ -35,5 +35,5 @@ data class FavoriteAvatar(
     @SerializedName("updated_at")
     var updatedAt: String = "",
     @SerializedName("version")
-    var version: Int = 0
+    var version: Long = 0
 )

--- a/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/FavoriteWorld.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/FavoriteWorld.kt
@@ -55,7 +55,7 @@ data class FavoriteWorld(
     @SerializedName("updated_at")
     var updatedAt: String = "",
     @SerializedName("version")
-    var version: Int = 0,
+    var version: Long = 0,
     @SerializedName("visits")
     var visits: Int = 0
 )

--- a/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/World.kt
+++ b/app/src/main/java/cc/sovellus/vrcaa/api/vrchat/models/World.kt
@@ -59,7 +59,7 @@ data class World(
     @SerializedName("updated_at")
     var updatedAt: String = "",
     @SerializedName("version")
-    var version: Int = 0,
+    var version: Long = 0,
     @SerializedName("visits")
     var visits: Int = 0
 )


### PR DESCRIPTION
Changes versions for all Json models to use Long instead of Int as any version above 2,147,483,647 will cause an instant crash, though rare this is possible and has been produced.